### PR TITLE
Install Concertim OpenStack billing service

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -190,6 +190,7 @@ If the cluster builder component is enabled, the following containers will be in
 If the openstack service components are enabled, the following containers will be installed:
 
 * `api_server` - Manages OpenStack users, projects and keys for Concertim.
+* `billing` - Manages interactions between the chosen billing application and other services.
 * `bulk_updates` - Periodically syncs OpenStack instance state to Concertim.
 * `mq_listener` - Listens to the Rabbit MQ to sync OpenStack changes to Concertim in real time.
 * `metrics` - Polls OpenStack for certain metrics and reports them to Concertim.
@@ -245,6 +246,7 @@ Other directories include:
 * `/opt/concertim/opt/visualisation-app/` the source code for Concertim Visualisation App.  It is used to build a docker image.
 * `/opt/concertim/opt/metric-reporting-daemon/` the source code for Concertim Metric Reporting Daemon.  It is used to build a docker image.
 * `/opt/concertim/opt/proxy/` configuration for building an nginx reverse proxy docker image.
+* `/opt/concertim/opt/openstack-service/` the source code for Concertim OpenStack Service.  It is used to build a docker image.
 
 
 ## Starting and stopping the Concertim services

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -127,6 +127,8 @@ openstack_service:
   docker_images:
     - name: concertim-api-server
       dockerfile: ./Dockerfiles/Dockerfile.api_server
+    - name: concertim-billing
+      dockerfile: ./Dockerfiles/Dockerfile.billing
     - name: concertim-bulk-updates
       dockerfile: ./Dockerfiles/Dockerfile.updates_bulk
     - name: concertim-mq-listener

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -94,6 +94,7 @@
       ansible.builtin.template:
         src: docker-compose.yml
         dest: "{{ct_docker_dir}}/"
+        lstrip_blocks: yes
 
 # Run any tasks that need to run after all of the containers and the docker
 # compose configuration is in place.  E.g., migrating databases.
@@ -109,7 +110,7 @@
       tags: concertim
       when: enable_concertim | bool
 
-- name: Start Alces Concertim components
+- name: Start Alces Concertim components and infrastructure
   hosts: all
   become: true
   become_user: root
@@ -118,16 +119,6 @@
     # Ensure all services are up.  If any needed restarting they will have been
     # downed in the previous plays, all that needs to happen here is ensure
     # they're up.
-    - name: Start concertim services
-      tags:
-        - concertim
-        - cluster_builder
-        - openstack_service
-      when: (enable_concertim | bool) or (enable_cluster_builder | bool) or (enable_openstack_service | bool)
-      ansible.builtin.shell:
-        chdir: "{{ct_docker_dir}}"
-        cmd: |
-          docker compose up --detach
 
     - name: Start killbill
       tags: killbill
@@ -136,3 +127,32 @@
         chdir: "{{ct_installation_dir}}/killbill"
         cmd: |
           docker compose up --detach
+
+    - tags:
+        - concertim
+        - cluster_builder
+        - openstack_service
+      when: (enable_concertim | bool) or (enable_cluster_builder | bool) or (enable_openstack_service | bool)
+      block:
+        # There is an order of initialisation issue where some
+        # concertim-openstack-service containers will exit if visualisation is
+        # not accepting connections when they start.  We work around that here,
+        # but it should be fixed upstream.
+      - name: Start concertim visualisation service
+        ansible.builtin.shell:
+          chdir: "{{ct_docker_dir}}"
+          cmd: |
+            docker compose up --detach visualisation
+
+      - name: Wait for visualisation container
+        ansible.builtin.wait_for:
+          port: "{{visualisation_app_port}}"
+          delay: 1
+          timeout: 10
+          msg: "Timed out waiting for visualisation port {{visualisation_app_port}} to become open on the host"
+
+      - name: Start concertim services
+        ansible.builtin.shell:
+          chdir: "{{ct_docker_dir}}"
+          cmd: |
+            docker compose up --detach

--- a/ansible/roles/concertim_common/tasks/main.yaml
+++ b/ansible/roles/concertim_common/tasks/main.yaml
@@ -11,3 +11,4 @@
     owner: root
     group: root
     mode: '0600'
+    lstrip_blocks: yes

--- a/ansible/roles/killbill/tasks/main.yml
+++ b/ansible/roles/killbill/tasks/main.yml
@@ -19,6 +19,7 @@
     owner: root
     group: root
     mode: '0600'
+    lstrip_blocks: yes
   notify:
     - "Stop killbill containers"
 
@@ -26,5 +27,6 @@
   ansible.builtin.template:
     src: docker-compose.yml
     dest: "{{killbill.install_dir}}"
+    lstrip_blocks: yes
   notify:
     - "Stop killbill containers"

--- a/ansible/roles/metric_reporting_daemon/tasks/main.yaml
+++ b/ansible/roles/metric_reporting_daemon/tasks/main.yaml
@@ -28,11 +28,13 @@
   ansible.builtin.template:
     src: config.yml
     dest: "{{ct_etc_dir}}/metric-reporting-daemon/"
+    lstrip_blocks: yes
 
 - name: Install gmetad configuration file
   ansible.builtin.template:
     src: gmetad.conf
     dest: "{{ct_etc_dir}}/metric-reporting-daemon/"
+    lstrip_blocks: yes
 
 - name: Set git checkout and docker image facts
   vars:

--- a/ansible/roles/openstack_service/handlers/main.yaml
+++ b/ansible/roles/openstack_service/handlers/main.yaml
@@ -2,4 +2,4 @@
   ansible.builtin.shell:
     chdir: "{{ct_docker_dir}}"
     cmd: |
-      docker compose down api_server bulk_updates mq_listener metrics
+      docker compose down api_server billing bulk_updates mq_listener metrics

--- a/ansible/roles/proxy/tasks/main.yaml
+++ b/ansible/roles/proxy/tasks/main.yaml
@@ -10,6 +10,7 @@
   ansible.builtin.template:
     src: default.conf
     dest: "{{proxy.install_dir}}/nginx/conf.d/default.conf"
+    lstrip_blocks: yes
   notify:
     - "Stop proxy container"
 
@@ -24,6 +25,7 @@
   ansible.builtin.template:
     src: Dockerfile
     dest: "{{proxy.install_dir}}/"
+    lstrip_blocks: yes
   notify:
     - "Stop proxy container"
 

--- a/ansible/roles/proxy/templates/default.conf
+++ b/ansible/roles/proxy/templates/default.conf
@@ -1,14 +1,14 @@
-{% if proxy_http_port -%}
+{% if proxy_http_port %}
 server {
   listen {{proxy_http_port}} default_server;
   listen [::]:{{proxy_http_port}} default_server;
 
   # Redirect all traffic to HTTPS.
-  {% if proxy_https_port == 443 -%}
+{% if proxy_https_port == 443 %}
   return 307 https://$host$request_uri;
-  {% else -%}
+{% else %}
   return 307 https://$host:{{proxy_https_port}}$request_uri;
-  {% endif %}
+{% endif %}
 }
 {% endif %}
 

--- a/ansible/templates/docker-compose.yml
+++ b/ansible/templates/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 name: concertim
 services:
-  {% if enable_concertim -%}
+{% if enable_concertim %}
   visualisation:
     image: concertim-visualisation-app:{{visualisation_app_facts_docker_image_tag}}
     volumes:
@@ -19,6 +19,7 @@ services:
       - PORT={{visualisation_app_port}}
     depends_on:
       - db
+      - proxy
     ports:
       - "{{visualisation_app_interface}}:{{visualisation_app_port}}:{{visualisation_app_port}}"
     network_mode: host
@@ -43,19 +44,18 @@ services:
     network_mode: host
     extra_hosts:
       - "visualisation:{{visualisation_app_ip}}"
+    depends_on:
+      - proxy
 
   proxy:
     image: concertim-proxy
     ports:
-      {% if proxy_http_port -%}
+{%    if proxy_http_port %}
       - "{{proxy_http_interface}}:{{proxy_http_port}}:{{proxy_http_port}}"
-      {% endif -%}
+{%    endif %}
       - "{{proxy_https_interface}}:{{proxy_https_port}}:{{proxy_https_port}}"
     volumes:
       - static-content:{{static_content_mount}}
-    depends_on:
-      - visualisation
-      - metric_reporting_daemon
     network_mode: host
     extra_hosts:
       - "metric_reporting_daemon:{{metric_reporting_daemon_ip}}"
@@ -79,9 +79,9 @@ services:
       timeout: 5s
       retries: 5
     network_mode: host
-  {% endif %}
+{% endif %}
 
-  {% if enable_cluster_builder -%}
+{% if enable_cluster_builder %}
   cluster_builder: 
     image: concertim-cluster-builder:{{cluster_builder_facts_docker_image_tag}}
     # flask requires SIGINT to stop gracefully
@@ -95,13 +95,24 @@ services:
     volumes:
       - "{{ct_cluster_builder_share_dir}}/:/app/instance"
     network_mode: host
-  {% endif %}
+{% endif %}
 
-  {% if enable_openstack_service -%}
+{% if enable_openstack_service %}
   api_server:
     image: concertim-api-server:{{openstack_service_facts_docker_image_tag}}
     ports:
       - "{{api_server_interface}}:42356:42356"
+    volumes:
+      - "{{ct_etc_dir}}/openstack-service/config.yaml:/etc/concertim-openstack-service/config.yaml"
+      - "{{ct_log_dir}}/openstack-service/:/app/var/log/"
+      - "{{ct_openstack_service_data_dir}}:/app/var/data/"
+    network_mode: host
+    extra_hosts:
+      - "proxy:{{proxy_ip}}"
+      - "killbill:{{killbill_ip}}"
+
+  billing:
+    image: concertim-billing:{{openstack_service_facts_docker_image_tag}}
     volumes:
       - "{{ct_etc_dir}}/openstack-service/config.yaml:/etc/concertim-openstack-service/config.yaml"
       - "{{ct_log_dir}}/openstack-service/:/app/var/log/"
@@ -142,9 +153,9 @@ services:
     network_mode: host
     extra_hosts:
       - "proxy:{{proxy_ip}}"
-  {% endif %}
+{% endif %}
 
-{% if enable_concertim -%}
+{% if enable_concertim %}
 volumes:
   db-data:
   rrd-data:


### PR DESCRIPTION
Somehow the billing service from Concertim OpenStack Service wasn't included in the initial all-in-one work.  This PR fixes that.

Including `billing` uncovered an order of initialisation issue where `billing` requires that `visualisation` is responding to requests when it starts.  If it isn't, `billing` will immediately exit.  This should be fixed in `billing`.  However, it is also worked around in this PR.  My initial attempt to do so was with docker compose's `depends_on` setting.  However that didn't work as `visualisation` takes some time to respond to requests after it's container has started.  This could be fixed with health checks and a `/ping` route in `visualisation`, however, I settled on an ansible task that waits for the `visualisation` port to become open.

My attempts to get `depends_on` working with the various permutations of the `enable_*` settings led me to banging my head on Jinja 2's whitespace stripping (or lack of it).  I've changed how ansible renders its jinja 2 templates to consistently add `lstrip_blocks: yes` and moving the jinja tags to the first character on the line.