### PR TITLE
Update go version for dev vm

### DIFF
--- a/contrib/dev/ansible/roles/appliance-dev/tasks/setup_dev_metric_daemon.yml
+++ b/contrib/dev/ansible/roles/appliance-dev/tasks/setup_dev_metric_daemon.yml
@@ -1,3 +1,13 @@
+- name: Add golang-backports repository
+  register: result
+  until: result is success
+  ansible.builtin.apt_repository:
+    repo: ppa:longsleep/golang-backports
+
+- name: Run the equivalent of "apt update"
+  ansible.builtin.apt:
+    update_cache: yes
+
 - name: Install dependencies
   register: result
   until: result is success


### PR DESCRIPTION
Updates the `go` version (required for the metric daemon) when building the development VM.