### PR TITLE
Run visualisation with RAILS_ENV=production

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -9,15 +9,13 @@
     ct_action: deploy
 
   pre_tasks:
-    - name: Assert credentials are present
+    - name: Assert GitHub credentials are present
       ansible.builtin.assert:
         that:
-          - "{{ item }} is defined"
-          - "{{ item }} != ''"
-        fail_msg: "{{ item }} credential has not been given"
+          - "gh_token is defined"
+          - "gh_token != ''"
+        fail_msg: "gh_token credential has not been given"
         quiet: true
-      loop:
-        - gh_token
 
     - name: Make installation directories
       ansible.builtin.file:
@@ -155,8 +153,8 @@
       - name: Wait for visualisation container
         ansible.builtin.wait_for:
           port: "{{visualisation_app_port}}"
-          delay: 1
-          timeout: 10
+          delay: 3
+          timeout: 300
           msg: "Timed out waiting for visualisation port {{visualisation_app_port}} to become open on the host"
 
       - name: Start concertim services

--- a/ansible/templates/docker-compose.yml
+++ b/ansible/templates/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - CREDENTIALS_CONTENT_PATH={{credentials_path}}
       - PORT={{visualisation_app_port}}
       - REDIS_URL="redis://{{redis_interface}}:{{redis_port}}/1"
+      - RAILS_ENV=production
     depends_on:
       - db
       - proxy

--- a/contrib/dev/vagrant/Vagrantfile
+++ b/contrib/dev/vagrant/Vagrantfile
@@ -60,7 +60,7 @@ Vagrant.configure("2") do |config|
         # Visualiser over HTTPS.
         v.vm.network "forwarded_port", guest:  7443, host: 9443 + idx + 1, host_ip: '127.0.0.1'
         # Killbill over HTTP.
-        v.vm.network "forwarded_port", guest: 49090, host: 9090,           host_ip: '127.0.0.1'
+        v.vm.network "forwarded_port", guest: 49090, host: 9090 + idx + 1, host_ip: '127.0.0.1'
       else
         # Visualiser over HTTP.
         v.vm.network "forwarded_port", guest:  80, host: 9080 + idx + 1, host_ip: '127.0.0.1'


### PR DESCRIPTION
Also merge in some other changes from my WIP dev-containers branch.

* Fix port clash when running two prod machines.  Its sometimes useful to run `dev1` as a "working on the apps" machine and `dev2` as a "working on the playbook" machine.  To do that we need to prevent port clashes when starting the vagrant machine.
* Up timeout waiting for visualisation app.
* Remove loop from asserting credentials. We're only checking one credential.