### PR TITLE
Set action cable allowed origins for prod

### DIFF
--- a/ansible/etc/globals.yaml
+++ b/ansible/etc/globals.yaml
@@ -53,10 +53,10 @@ visualisation_app_port: 7000
 # The interface that the proxy service should listen to HTTPS requests on.
 # Use 0.0.0.0 to listen on all interfaces.
 visualisation_app_interface: 127.0.0.1
-# The hosts that visualiser's action cable (websockets) should allow requests from.
-# If multiple, these should be separated by a comma.
-# Comment this line out to use the hostname detected by ansible.
-action_cable_allowed_origins: https://localhost:9444,https://127.0.0.1:9444
+# The hostname(s) that will be used to access concertim (i.e. the hostname that users type into their browser).
+# If not set, it will default to the fully qualified hostname of the machine concertim is installed on.
+#access_hostnames:
+#  - myhostname.mydomain
 
 # The port that the redis service should listen to HTTP requests on.
 redis_port: 46379

--- a/ansible/templates/docker-compose.yml
+++ b/ansible/templates/docker-compose.yml
@@ -18,7 +18,11 @@ services:
       - CREDENTIALS_CONTENT_PATH={{credentials_path}}
       - PORT={{visualisation_app_port}}
       - REDIS_URL="redis://{{redis_interface}}:{{redis_port}}/1"
-      - ACTION_CABLE_ALLOWED_ORIGINS={{action_cable_allowed_origins | default(ansible_facts.hostname)}}
+      {% if access_hostnames is not defined or access_hostnames is none %}
+      - ACTION_CABLE_ALLOWED_ORIGINS={{ansible_facts.hostname}}
+      {% else %}
+      - ACTION_CABLE_ALLOWED_ORIGINS={{access_hostnames | join(",")}}
+      {% endif %}
       - RAILS_ENV=production
     depends_on:
       - db


### PR DESCRIPTION
Enables use of visualiser's websockets when running in production mode, by setting the environment variable `ACTION_CABLE_ALLOWED_ORIGINS`

This is defined in `ansible/etc/globals.yaml`, but if not present here, will be set to the value of `ansible_facts.hostname`. 

When setting the allowed origins, the port can optionally be set - if no port is specified, any port is allowed. Likewise the protocol can optionally be set (http or https) and if no protocol included, both are allowed.

Linked to https://github.com/alces-flight/concertim-ct-visualisation-app/pull/108