### PR TITLE
Generate and pass shared jwt secret

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -54,6 +54,19 @@
           group: root
           mode: "700"
 
+    - name: Ensure shared jwt secret exists
+      ansible.builtin.set_fact:
+          jwt_secret: "{{ lookup('password', '{{ct_docker_dir}}/secrets/jwt-secret chars=ascii_letters,digits length=32') }}"
+
+    - name: Create shared jwt secret env file
+      ansible.builtin.template:
+          src: jwt_secret.env
+          dest: "{{ct_docker_dir}}/secrets"
+          owner: root
+          group: root
+          mode: '0600'
+          lstrip_blocks: yes
+
   roles:
     - role: concertim_common
       tags: concertim

--- a/ansible/roles/concertim_common/tasks/main.yaml
+++ b/ansible/roles/concertim_common/tasks/main.yaml
@@ -1,7 +1,6 @@
 - name: Ensure docker secrets exist
   ansible.builtin.set_fact:
     db_password: "{{ lookup('password', '{{ct_docker_dir}}/secrets/db-password chars=ascii_letters,digits length=32') }}"
-    jwt_secret: "{{ lookup('password', '{{ct_docker_dir}}/secrets/jwt-secret chars=ascii_letters,digits length=32') }}"
     rails_master_key: "{{ lookup('password', '{{ct_docker_dir}}/secrets/rails-master-key chars=ascii_letters,digits length=32') }}"
     redis_password: "{{ lookup('password', '{{ct_docker_dir}}/secrets/redis-password chars=ascii_letters,digits length=32') }}"
 

--- a/ansible/roles/concertim_common/templates/secrets.env
+++ b/ansible/roles/concertim_common/templates/secrets.env
@@ -1,4 +1,3 @@
 POSTGRES_PASSWORD={{db_password}}
-JWT_SECRET={{jwt_secret}}
 RAILS_MASTER_KEY={{rails_master_key}}
 REDIS_PASSWORD={{redis_password}}

--- a/ansible/templates/docker-compose.yml
+++ b/ansible/templates/docker-compose.yml
@@ -11,6 +11,7 @@ services:
         target: "{{ct_etc_mount}}"
     env_file:
       - secrets/secrets.env
+      - secrets/jwt_secret.env
     environment:
       - METRIC_DAEMON_URL=http://metric_reporting_daemon:{{metric_reporting_daemon_api_port}}
       - POSTGRES_HOST=db
@@ -55,6 +56,7 @@ services:
         target: "{{ct_etc_mount}}/metric-reporting-daemon"
     env_file:
       - secrets/secrets.env
+      - secrets/jwt_secret.env
     ports:
       - "{{metric_reporting_daemon_api_interface}}:{{metric_reporting_daemon_api_port}}:{{metric_reporting_daemon_api_port}}"
     network_mode: host
@@ -106,6 +108,8 @@ services:
     environment:
       - PORT={{cluster_builder_port}}
       - HOST={{cluster_builder_interface}}
+    env_file:
+      - secrets/jwt_secret.env
     ports:
       - "{{cluster_builder_interface}}:{{cluster_builder_port}}:{{cluster_builder_port}}"
     volumes:
@@ -118,6 +122,8 @@ services:
 {% if enable_openstack_service %}
   api_server:
     image: concertim-api-server:{{openstack_service_facts_docker_image_tag}}
+    env_file:
+      - secrets/jwt_secret.env
     ports:
       - "{{api_server_interface}}:42356:42356"
     volumes:
@@ -131,6 +137,8 @@ services:
 
   billing:
     image: concertim-billing:{{openstack_service_facts_docker_image_tag}}
+    env_file:
+      - secrets/jwt_secret.env
     volumes:
       - "{{ct_etc_dir}}/openstack-service/config.yaml:/etc/concertim-openstack-service/config.yaml"
       - "{{ct_log_dir}}/openstack-service/:/app/var/log/"
@@ -142,6 +150,8 @@ services:
 
   bulk_updates:
     image: concertim-bulk-updates:{{openstack_service_facts_docker_image_tag}}
+    env_file:
+      - secrets/jwt_secret.env
     volumes:
       - "{{ct_etc_dir}}/openstack-service/config.yaml:/etc/concertim-openstack-service/config.yaml"
       - "{{ct_log_dir}}/openstack-service/:/app/var/log/"
@@ -153,6 +163,8 @@ services:
 
   mq_listener:
     image: concertim-mq-listener:{{openstack_service_facts_docker_image_tag}}
+    env_file:
+      - secrets/jwt_secret.env
     volumes:
       - "{{ct_etc_dir}}/openstack-service/config.yaml:/etc/concertim-openstack-service/config.yaml"
       - "{{ct_log_dir}}/openstack-service/:/app/var/log/"
@@ -164,6 +176,8 @@ services:
 
   metrics:
     image: concertim-metrics:{{openstack_service_facts_docker_image_tag}}
+    env_file:
+      - secrets/jwt_secret.env
     volumes:
       - "{{ct_etc_dir}}/openstack-service/config.yaml:/etc/concertim-openstack-service/config.yaml"
       - "{{ct_log_dir}}/openstack-service/:/app/var/log/"

--- a/ansible/templates/jwt_secret.env
+++ b/ansible/templates/jwt_secret.env
@@ -1,0 +1,1 @@
+JWT_SECRET={{jwt_secret}}


### PR DESCRIPTION
For prod deployment:

- Separates out generation of a shared `jwt_secret` so this is always created (regardless of application choices)
- This secret is now additionally made available to the openstack service and cluster builder containers as an environment variable (`JWT_SECRET`)
- This is with the intention of those applications using this secret to validate bearer tokens received from visualiser (and potentially for other cross application communication in the future)

Linked to https://github.com/alces-flight/concertim-ct-visualisation-app/pull/135