### PR TITLE
Add user_handler extra host to cluster builder

### DIFF
--- a/ansible/templates/docker-compose.yml
+++ b/ansible/templates/docker-compose.yml
@@ -111,6 +111,8 @@ services:
     volumes:
       - "{{ct_cluster_builder_share_dir}}/:/app/instance"
     network_mode: host
+    extra_hosts:
+      - "user_handler:{{api_server_ip}}"
 {% endif %}
 
 {% if enable_openstack_service %}


### PR DESCRIPTION
The default configuration for concertim assumes that the middleware services are available on a host called `user_handler`.  This is made true by docker extra hosts setting.

Concertim now passes the URL for the user handler to cluster builder, so we need to have its container configured with the extra hosts too.

Refs https://github.com/alces-flight/concertim-ct-visualisation-app/pull/137
Refs https://github.com/alces-flight/concertim-cluster-builder/pull/22