### PR TITLE
Fix installation of cluster builder cluster types

### DIFF
--- a/ansible/roles/cluster_builder/tasks/main.yaml
+++ b/ansible/roles/cluster_builder/tasks/main.yaml
@@ -20,7 +20,6 @@
   vars:
     available_dir: "{{ct_cluster_builder_share_dir}}/cluster-types-available"
     enabled_dir: "{{ct_cluster_builder_share_dir}}/cluster-types-enabled"
-    hot_dir: "{{ct_cluster_builder_share_dir}}/hot"
   block:
     - name: Create cluster type definition directories
       ansible.builtin.file:
@@ -32,7 +31,6 @@
       loop:
         - "{{available_dir}}"
         - "{{enabled_dir}}"
-        - "{{hot_dir}}"
 
     - name: Copy examples cluster type definitions
       ansible.builtin.copy:
@@ -42,15 +40,22 @@
       loop:
         - src: cluster-types/
           dest: "{{available_dir}}"
-        - src: hot/
-          dest: "{{hot_dir}}"
+
+    - name: Find available types
+      ansible.builtin.find:
+        path: "{{available_dir}}"
+        depth: 2
+        file_type: file
+        pattern: "cluster-type.yaml"
+        recurse: true
+      register: available_types
 
     - name: Enable all available types
       ansible.builtin.file:
-        src: "../cluster-types-available/{{item | basename}}"
-        dest: "{{enabled_dir}}/{{item | basename}}"
+        src: "../cluster-types-available/{{item.path | dirname | basename}}"
+        dest: "{{enabled_dir}}/{{item.path | dirname | basename}}"
         state: link
-      loop: "{{ query('fileglob', available_dir+'/*.yaml') }}"
+      loop: "{{ available_types.files }}"
 
 - name: Set git checkout and docker image facts
   vars:


### PR DESCRIPTION
The format has changed in cluster builder.  This commit updates the role to the new format.