### PR TITLE
Support all apps logging to files instead of stdout

### DIFF
--- a/ansible/roles/cluster_builder/tasks/main.yaml
+++ b/ansible/roles/cluster_builder/tasks/main.yaml
@@ -16,6 +16,19 @@
   ansible.builtin.command:
     cmd: git config --global --add safe.directory "{{cluster_builder.install_dir}}"
 
+- name: Create directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode: "{{ item.mode }}"
+    state: directory
+  loop:
+    - path: "{{ct_log_dir}}/cluster-builder"
+      owner: root
+      group: root
+      mode: "755"
+
 - name: Copy cluster type definitions
   vars:
     available_dir: "{{ct_cluster_builder_share_dir}}/cluster-types-available"

--- a/ansible/roles/metric_reporting_daemon/tasks/main.yaml
+++ b/ansible/roles/metric_reporting_daemon/tasks/main.yaml
@@ -16,13 +16,22 @@
   ansible.builtin.command:
     cmd: git config --global --add safe.directory "{{metric_reporting_daemon.install_dir}}"
 
-- name: Create configuration directory
+- name: Create directories
   ansible.builtin.file:
-    path: "{{ct_etc_dir}}/metric-reporting-daemon"
-    owner: root
-    group: root
-    mode: "755"
+    path: "{{ item.path }}"
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode: "{{ item.mode }}"
     state: directory
+  loop:
+    - path: "{{ct_etc_dir}}/metric-reporting-daemon"
+      owner: root
+      group: root
+      mode: "755"
+    - path: "{{ct_log_dir}}/metric-reporting-daemon"
+      owner: root
+      group: root
+      mode: "755"
 
 - name: Install metric reporting daemon configuration file
   ansible.builtin.template:

--- a/ansible/roles/metric_reporting_daemon/templates/config.yml
+++ b/ansible/roles/metric_reporting_daemon/templates/config.yml
@@ -76,4 +76,5 @@ rrd:
   step: 15s
 
 log_level: info
+log_file: /app/log/metric-reporting-daemon.log
 shared_secret_file: "/opt/concertim/etc/secret"

--- a/ansible/roles/visualisation_app/tasks/deploy.yaml
+++ b/ansible/roles/visualisation_app/tasks/deploy.yaml
@@ -17,6 +17,19 @@
   ansible.builtin.command:
     cmd: git config --global --add safe.directory "{{visualisation_app.install_dir}}"
 
+- name: Create directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode: "{{ item.mode }}"
+    state: directory
+  loop:
+    - path: "{{ct_log_dir}}/visualisation/"
+      owner: root
+      group: root
+      mode: "755"
+
 - name: Set git checkout and docker image facts
   vars:
     component: visualisation_app

--- a/ansible/templates/docker-compose.yml
+++ b/ansible/templates/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - type: bind
         source: "{{ct_etc_dir}}"
         target: "{{ct_etc_mount}}"
+      - "{{ct_log_dir}}/visualisation/:/opt/concertim/opt/ct-visualisation-app/log"
     env_file:
       - secrets/secrets.env
       - secrets/jwt_secret.env
@@ -61,6 +62,7 @@ services:
       - type: bind
         source: "{{ct_etc_dir}}/metric-reporting-daemon"
         target: "{{ct_etc_mount}}/metric-reporting-daemon"
+      - "{{ct_log_dir}}/metric-reporting-daemon/:/app/log"
     env_file:
       - secrets/secrets.env
       - secrets/jwt_secret.env
@@ -121,6 +123,7 @@ services:
       - "{{cluster_builder_interface}}:{{cluster_builder_port}}:{{cluster_builder_port}}"
     volumes:
       - "{{ct_cluster_builder_share_dir}}/:/app/instance"
+      - "{{ct_log_dir}}/cluster-builder/:/app/log"
     network_mode: host
     extra_hosts:
       - "user_handler:{{api_server_ip}}"

--- a/contrib/dev/ansible-dev-containers/templates/docker-compose.dev.yml
+++ b/contrib/dev/ansible-dev-containers/templates/docker-compose.dev.yml
@@ -24,6 +24,8 @@ services:
       - type: bind
         source: "{{cluster_builder.install_dir}}"
         target: "/app"
+    environment:
+      - CONFIG_FILE=/app/config/config.dev.yaml
     command: ["flask", "--app", "cluster_builder", "run", "-h", "0.0.0.0", "-p", "42378", "--debug"]
 {% endif %}
 


### PR DESCRIPTION
Middleware already did this; now visualisation, metric reporting daemon and cluster builder do it too.