### PR TITLE
added opensource information

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behaviour that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behaviour by participants include:
+
+* The use of sexualised language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behaviour and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behaviour.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviours that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported by contacting the project team at [help@openflighthpc.org](help@openflighthpc.org). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,184 @@
+# Contributing to Concertim Ansible Playbook
+
+:+1::tada: Thanks for taking the time to contribute! :tada::+1:
+
+You want to contribute to Concertim Ansible Playbook? Welcome! Please read this
+document to understand what you can do:
+
+* [Code of Conduct](#code-of-conduct)
+* [Help Others](#help-others)
+* [Analyse Issues](#analyse-issues)
+* [Report an Issue](#report-an-issue)
+* [Contribute Changes](#contribute-changes)
+
+When contributing to this repository, please first discuss the change
+you wish to make via a Github issue or a post on the [OpenFlight
+Community site](https://community.openflighthpc.org).
+
+Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please
+follow it in all your interactions with the project.
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the
+[OpenFlight Code of Conduct](CODE_OF_CONDUCT.md). By participating,
+you are expected to uphold this code. Please report unacceptable
+behaviour to [help@openflighthpc.org](mailto:help@openflighthpc.org).
+
+## Help Others
+
+You can help Concertim Ansible Playbook by helping others who use it and need support.
+
+## Analyse Issues
+
+Analysing issue reports can be a lot of effort. Any help is welcome!
+Go to [the GitHub issue tracker](https://github.com/openflighthpc/concertim-ansible-playbook/issues?state=open)
+and find an open issue which needs additional work or a bugfix
+(e.g. issues labeled with "help wanted" or "bug").
+
+Additional work could include any further information, or a gist, or
+it might be a hint that helps understanding the issue. Maybe you can
+even find and [contribute](#contribute-changes) a bugfix?
+
+## Report an Issue
+
+If you find a bug - behaviour of Concertim Ansible Playbook code or documentation
+contradicting your expectation - you are welcome to report it. We can
+only handle well-reported, actual bugs, so please follow the
+guidelines below.
+
+Once you have familiarised with the guidelines, you can go to the
+[GitHub issue tracker for Concertim Ansible Playbook](https://github.com/openflighthpc/concertim-ansible-playbook/issues/new)
+to report the issue.
+
+### Quick Checklist for Bug Reports
+
+Issue report checklist:
+
+* Real, current bug
+* No duplicate
+* Reproducible
+* Good summary
+* Well-documented
+* Minimal example
+
+### Issue handling process
+
+When an issue is reported, a committer will look at it and either
+confirm it as a real issue, close it if it is not an issue, or ask for
+more details.
+
+An issue that is about a real bug is closed as soon as the fix is committed.
+
+### Reporting Security Issues
+
+If you find a security issue, please act responsibly and report it not
+in the public issue tracker, but directly to us, so we can fix it
+before it can be exploited.  Please send the related information to
+[security@openflighthpc.org](mailto:security@openflighthpc.org).
+
+### Issue Reporting Disclaimer
+
+We want to improve the quality of Concertim Ansible Playbook and good bug reports are
+welcome! However, our capacity is limited, thus we reserve the right
+to close or to not process bug reports with insufficient detail in
+favour of those which are very cleanly documented and easy to
+reproduce. Even though we would like to solve each well-documented
+issue, there is always the chance that it will not happen - remember:
+Concertim Ansible Playbook is Open Source and comes without warranty.
+
+Bug report analysis support is very welcome! (e.g. pre-analysis or
+proposing solutions)
+
+## Contribute Changes
+
+You are welcome to contribute code, content or documentation to
+Concertim Ansible Playbook in order to fix bugs or to implement new features.
+
+There are three important things to know:
+
+1. You must be aware of the Eclipse Public License 2.0 (which
+   describes contributions) and **agree to the Contributors License
+   Agreement**. This is common practice in all major Open Source
+   projects.
+2. **Not all proposed contributions can be accepted**. Some features
+   may e.g. just fit a third-party add-on better. The change must fit
+   the overall direction of Concertim Ansible Playbook and really improve it. The more
+   effort you invest, the better you should clarify in advance whether
+   the contribution fits: the best way would be to just open an issue
+   to discuss the feature you plan to implement (make it clear you
+   intend to contribute).
+
+### Contributor License Agreement
+
+When you contribute (code, documentation, or anything else), you have
+to be aware that your contribution is covered by the same [Eclipse
+Public License 2.0](https://opensource.org/licenses/EPL-2.0) that is
+applied to Concertim Ansible Playbook itself.
+
+In particular you need to agree to the Contributor License Agreement,
+which can be [found
+here](https://www.clahub.com/agreements/openflighthpc/concertim-ansible-playbook). This
+applies to all contributors, including those contributing on behalf of
+a company. If you agree to its content, you simply have to click on
+the link posted by the CLA assistant available on the pull
+request. Click it to check the CLA, then accept it on the following
+screen if you agree to it. CLA assistant will save this decision for
+upcoming contributions and will notify you if there is any change to
+the CLA in the meantime.
+
+## Pull Request Process
+
+1. Make sure the change would be welcome (e.g. a bugfix or a useful
+   feature); best do so by proposing it in a GitHub issue.
+2. Fork, then clone the repo.
+3. Make your changes ([see below](#making-changes)) and commit.
+4. In the commit message:
+    - Describe the problem you fix with this change.
+    - Describe the effect that this change has from a user's point of
+      view. App crashes and lockups are pretty convincing for example,
+      but not all bugs are that obvious and should be mentioned in the
+      text.
+    - Describe the technical details of what you changed. It is
+      important to describe the change in a most understandable way so
+      the reviewer is able to verify that the code is behaving as you
+      intend it to.
+5. If your change fixes an issue reported at GitHub, add the following
+   line to the commit message:
+    - `Fixes #(issueNumber)`
+    - Do NOT add a colon after "Fixes" - this prevents automatic closing.
+6. Open a pull request!
+7. Follow the link posted by the CLA assistant to your pull request
+   and accept it, as described in detail above.
+8. Wait for our code review and approval, possibly enhancing your
+   change on request.
+    - Note that the Concertim Ansible Playbook developers also have their regular
+      duties, so depending on the required effort for reviewing,
+      testing and clarification this may take a while.
+9. Once the change has been approved we will inform you in a comment.
+10. We will close the pull request; feel free to delete the now
+    obsolete branch.
+
+## Making Changes
+
+1. Create a topic branch from where you want to base your work.
+    * This is usually the `master` branch.
+    * Only target release branches if you are certain your fix must be
+      on that branch.
+    * To quickly create a topic branch based on master, run `git
+      checkout -b fix/master/my_contribution master`. Please avoid
+      working directly on the `master` branch.
+2. Make commits of logical and atomic units.
+3. Check for unnecessary whitespace with `git diff --check` before
+   committing.
+
+## Attribution
+
+These contribution guidelines are adapted from
+[various](https://github.com/cla-assistant/cla-assistant/blob/master/CONTRIBUTING.md)
+[previous](https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md)
+[contribution](https://gist.github.com/PurpleBooth/b24679402957c63ec426)
+[guideline](https://github.com/atom/atom/blob/master/CONTRIBUTING.md)
+documents from other projects hosted on Github. Our thanks to the
+respective authors for making contributing to Open Source projects a
+more streamlined and efficient process!

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,277 @@
+Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set forth
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.

--- a/README.md
+++ b/README.md
@@ -46,3 +46,30 @@ For details on how to develop and test the ansible deployment playbook see
 
 If you are looking for details on how to develop the Concertim services
 themselves see the [contrib/dev/README.md](contrib/dev/README.md).
+
+# Contributing
+
+Fork the project. Make your feature addition or bug fix. Send a pull
+request. Bonus points for topic branches.
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
+
+# Copyright and License
+
+Eclipse Public License 2.0, see [LICENSE.txt](LICENSE.txt) for details.
+
+Copyright (C) 2024-present Alces Flight Ltd.
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which is available at
+[https://www.eclipse.org/legal/epl-2.0](https://www.eclipse.org/legal/epl-2.0),
+or alternative license terms made available by Alces Flight Ltd -
+please direct inquiries about licensing to
+[licensing@alces-flight.com](mailto:licensing@alces-flight.com).
+
+Concertim Ansible Playbook is distributed in the hope that it will be
+useful, but WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER
+EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR
+CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR
+A PARTICULAR PURPOSE. See the [Eclipse Public License 2.0](https://opensource.org/licenses/EPL-2.0) for more
+details.


### PR DESCRIPTION
Adds files and information indicating that this is now (going to be) open source, under the Eclipse Public License - v 2.0 license

Subsequently this repo will need transfering to [openflighthpc](https://github.com/openflighthpc).

Paths to the concertim applications will also need updating once those apps are moved to openflighthpc.