### PR TITLE
Use master openstack branch

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -125,7 +125,7 @@ openstack_service:
   install_dir: "{{ct_installation_dir}}/openstack-service"
   source:
     repo: "https://{{gh_token}}@github.com/openflighthpc/concertim-openstack-service"
-    commitish: code-abstraction
+    commitish: master
   docker_images:
     - name: concertim-api-server
       dockerfile: ./Dockerfiles/Dockerfile.api_server


### PR DESCRIPTION
Updates openstack service branch to use `master` instead of the now outdated `code-abstraction` branch